### PR TITLE
PAT-1949 Support storage-api-php-client-branch-wrapper ^7.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -41,7 +41,7 @@
         "keboola/php-api-client-base": "*@dev",
         "keboola/service-client": "*@dev",
         "keboola/storage-api-client": "^17.0|^18.0",
-        "keboola/storage-api-php-client-branch-wrapper": "^6.0",
+        "keboola/storage-api-php-client-branch-wrapper": "^7.0",
         "keboola/vault-api-client": "*@dev",
         "mustache/mustache": "^2.13",
         "psr/log": "^1.1|^2.0|^3.0",

--- a/tests/SharedCodeResolverTest.php
+++ b/tests/SharedCodeResolverTest.php
@@ -14,6 +14,7 @@ use Keboola\StorageApi\Options\Components\Configuration as StorageConfiguration;
 use Keboola\StorageApi\Options\Components\ConfigurationRow;
 use Keboola\StorageApi\Options\Components\ListComponentConfigurationsOptions;
 use Keboola\StorageApiBranch\ClientWrapper;
+use Keboola\StorageApiBranch\Factory\AuthType;
 use Keboola\StorageApiBranch\Factory\ClientOptions;
 use Monolog\Handler\TestHandler;
 use Monolog\Logger;
@@ -35,6 +36,7 @@ class SharedCodeResolverTest extends TestCase
             new ClientOptions(
                 (string) getenv('STORAGE_API_URL'),
                 (string) getenv('STORAGE_API_TOKEN'),
+                authType: AuthType::STORAGE_TOKEN,
             ),
         );
         $components = new Components($this->clientWrapper->getBasicClient());
@@ -315,6 +317,7 @@ class SharedCodeResolverTest extends TestCase
             new ClientOptions(
                 (string) getenv('STORAGE_API_URL'),
                 (string) getenv('STORAGE_API_TOKEN_MASTER'),
+                authType: AuthType::STORAGE_TOKEN,
             ),
         );
         $branchId = $this->createBranch('my-dev-branch', $clientWrapper);
@@ -323,6 +326,7 @@ class SharedCodeResolverTest extends TestCase
                 (string) getenv('STORAGE_API_URL'),
                 (string) getenv('STORAGE_API_TOKEN'),
                 (string) $branchId,
+                authType: AuthType::STORAGE_TOKEN,
             ),
         );
 

--- a/tests/UnifiedConfigurationResolverFactoryTest.php
+++ b/tests/UnifiedConfigurationResolverFactoryTest.php
@@ -9,6 +9,7 @@ use Keboola\ConfigurationVariablesResolver\VaultVariablesApiClientConfiguration;
 use Keboola\ServiceClient\ServiceClient;
 use Keboola\StorageApi\BranchAwareClient;
 use Keboola\StorageApiBranch\ClientWrapper;
+use Keboola\StorageApiBranch\Factory\AuthType;
 use Keboola\StorageApiBranch\StorageApiToken;
 use PHPUnit\Framework\TestCase;
 use Psr\Log\NullLogger;
@@ -79,7 +80,7 @@ class UnifiedConfigurationResolverFactoryTest extends TestCase
         $clientWrapperMock->method('getBranchClient')
             ->willReturn($branchAwareClientMock);
         $clientWrapperMock->method('getToken')
-            ->willReturn(new StorageApiToken([], 'token'));
+            ->willReturn(new StorageApiToken([], 'token', AuthType::STORAGE_TOKEN));
 
         $unifiedVariablesResolver = $this->getFactory()->createResolver($clientWrapperMock);
 
@@ -154,7 +155,7 @@ class UnifiedConfigurationResolverFactoryTest extends TestCase
         $clientWrapperMock->method('getBranchClient')
             ->willReturn($branchAwareClientMock);
         $clientWrapperMock->method('getToken')
-            ->willReturn(new StorageApiToken([], 'token'));
+            ->willReturn(new StorageApiToken([], 'token', AuthType::STORAGE_TOKEN));
 
         $unifiedVariablesResolver = $this->getFactory()->createResolver(
             $clientWrapperMock,
@@ -195,7 +196,7 @@ class UnifiedConfigurationResolverFactoryTest extends TestCase
         $clientWrapperMock->method('getBranchClient')
             ->willReturn($branchAwareClientMock);
         $clientWrapperMock->method('getToken')
-            ->willReturn(new StorageApiToken([], 'token'));
+            ->willReturn(new StorageApiToken([], 'token', AuthType::STORAGE_TOKEN));
 
         $unifiedVariablesResolver = $this->getFactory()->createResolver(
             $clientWrapperMock,

--- a/tests/VariableResolverTest.php
+++ b/tests/VariableResolverTest.php
@@ -13,6 +13,7 @@ use Keboola\StorageApi\DevBranches;
 use Keboola\StorageApi\Options\Components\Configuration as StorageConfiguration;
 use Keboola\StorageApi\Options\Components\ConfigurationRow;
 use Keboola\StorageApiBranch\ClientWrapper;
+use Keboola\StorageApiBranch\Factory\AuthType;
 use Keboola\StorageApiBranch\Factory\ClientOptions;
 use Keboola\VaultApiClient\Variables\VariablesApiClient;
 use Monolog\Handler\TestHandler;
@@ -44,6 +45,7 @@ class VariableResolverTest extends TestCase
             new ClientOptions(
                 (string) getenv('STORAGE_API_URL'),
                 (string) getenv('STORAGE_API_TOKEN'),
+                authType: AuthType::STORAGE_TOKEN,
             ),
         );
     }
@@ -555,6 +557,7 @@ class VariableResolverTest extends TestCase
             new ClientOptions(
                 (string) getenv('STORAGE_API_URL'),
                 (string) getenv('STORAGE_API_TOKEN_MASTER'),
+                authType: AuthType::STORAGE_TOKEN,
             ),
         );
 
@@ -564,6 +567,7 @@ class VariableResolverTest extends TestCase
                 (string) getenv('STORAGE_API_URL'),
                 (string) getenv('STORAGE_API_TOKEN_MASTER'),
                 (string) $branchId,
+                authType: AuthType::STORAGE_TOKEN,
             ),
         );
 

--- a/tests/VariablesResolver/ConfigurationVariablesResolverTest.php
+++ b/tests/VariablesResolver/ConfigurationVariablesResolverTest.php
@@ -14,6 +14,7 @@ use Keboola\StorageApi\DevBranches;
 use Keboola\StorageApi\Options\Components\Configuration as StorageConfiguration;
 use Keboola\StorageApi\Options\Components\ConfigurationRow;
 use Keboola\StorageApiBranch\ClientWrapper;
+use Keboola\StorageApiBranch\Factory\AuthType;
 use Keboola\StorageApiBranch\Factory\ClientOptions;
 use Monolog\Handler\TestHandler;
 use Monolog\Logger;
@@ -42,6 +43,7 @@ class ConfigurationVariablesResolverTest extends TestCase
             new ClientOptions(
                 (string) getenv('STORAGE_API_URL'),
                 (string) getenv('STORAGE_API_TOKEN'),
+                authType: AuthType::STORAGE_TOKEN,
             ),
         );
     }
@@ -507,6 +509,7 @@ class ConfigurationVariablesResolverTest extends TestCase
             new ClientOptions(
                 (string) getenv('STORAGE_API_URL'),
                 (string) getenv('STORAGE_API_TOKEN_MASTER'),
+                authType: AuthType::STORAGE_TOKEN,
             ),
         );
 
@@ -516,6 +519,7 @@ class ConfigurationVariablesResolverTest extends TestCase
                 (string) getenv('STORAGE_API_URL'),
                 (string) getenv('STORAGE_API_TOKEN_MASTER'),
                 (string) $branchId,
+                authType: AuthType::STORAGE_TOKEN,
             ),
         );
 

--- a/tests/VariablesResolverFunctionalTest.php
+++ b/tests/VariablesResolverFunctionalTest.php
@@ -14,6 +14,7 @@ use Keboola\StorageApi\Options\Components\Configuration as StorageConfiguration;
 use Keboola\StorageApi\Options\Components\ConfigurationRow;
 use Keboola\StorageApi\Options\Components\ListComponentConfigurationsOptions;
 use Keboola\StorageApiBranch\ClientWrapper;
+use Keboola\StorageApiBranch\Factory\AuthType;
 use Keboola\StorageApiBranch\Factory\ClientOptions;
 use Keboola\VaultApiClient\Variables\Model\ListOptions;
 use Keboola\VaultApiClient\Variables\VariablesApiClient;
@@ -48,6 +49,7 @@ class VariablesResolverFunctionalTest extends TestCase
             new ClientOptions(
                 self::getRequiredEnv('STORAGE_API_URL'),
                 self::getRequiredEnv('STORAGE_API_TOKEN'),
+                authType: AuthType::STORAGE_TOKEN,
             ),
         );
 
@@ -189,6 +191,7 @@ class VariablesResolverFunctionalTest extends TestCase
             new ClientOptions(
                 (string) getenv('STORAGE_API_URL'),
                 (string) getenv('STORAGE_API_TOKEN_MASTER'),
+                authType: AuthType::STORAGE_TOKEN,
             ),
         );
         $branchesApiClient = new DevBranches($masterClientWrapper->getBasicClient());
@@ -205,6 +208,7 @@ class VariablesResolverFunctionalTest extends TestCase
                 (string) getenv('STORAGE_API_URL'),
                 (string) getenv('STORAGE_API_TOKEN_MASTER'),
                 (string) $devBranch['id'],
+                authType: AuthType::STORAGE_TOKEN,
             ),
         );
 


### PR DESCRIPTION
## Release Notes
https://linear.app/keboola/issue/PAT-1949

`keboola/storage-api-php-client-branch-wrapper` is bumped to `^7.0`, which in turn pulls `keboola/storage-api-client` up to `^18.6+`. This unblocks the downstream `keboola/api-bundle` upgrade in `data-loader-api` (PAT-1949).

branch-wrapper 7.0 introduces two breaking changes: `StorageApiToken`'s constructor now requires a third `AuthType $tokenType` argument, and building a `ClientWrapper` from a `ClientOptions` instance that carries a token now requires `authType` to be set on it. Production code in `src/` is unaffected since it only interacts with `ClientWrapper`/`ClientOptions` via the caller-supplied instances and never constructs `StorageApiToken` directly; only test fixtures needed updating. All affected tokens are legacy Storage API tokens, so every site uses `AuthType::STORAGE_TOKEN`. This is a hard move to `^7.0` (6.x support dropped) and is intended to ship as a minor version bump.

## Plans for customer communication
None.

## Impact analysis
No end-user impact. Test-only change; production code is unaffected.

## Change type
Maintenance

## Justification
Unblock the `keboola/api-bundle` upgrade in `data-loader-api` (PAT-1949).

## Deployment
Merge & automatic deploy.

## Rollback plan
Revert of this PR.

## Post release support plan
None.